### PR TITLE
Feat: 메인 페이지 api 수정

### DIFF
--- a/public/data/allAccommodations.json
+++ b/public/data/allAccommodations.json
@@ -14,9 +14,9 @@
         "category": "HOTELRESORT",
         "lowestPrice": 95000,
         "discountPrice": 80000,
-        "imageUrl": "https://avatars.githubusercontent.com/u/81469686?v=4",
+        "imageUrl": "https://josunhotel.com/util/file/download.do?fileSn=1763080&sysCode=TWC",
         "soldOut": false,
-        "coupon": "10000원 할인"
+        "coupon": "10,000원 즉시 할인"
       },
       {
         "id": 2,
@@ -24,10 +24,10 @@
         "address": "서울특별시 중구 소공로 106",
         "category": "HOTELRESORT",
         "lowestPrice": 95000,
-        "discountPrice": 80000,
-        "imageUrl": "https://avatars.githubusercontent.com/u/81469686?v=4",
+        "discountPrice": 0,
+        "imageUrl": "https://josunhotel.com/util/file/download.do?fileSn=1763080&sysCode=TWC",
         "soldOut": false,
-        "coupon": "10000원 할인"
+        "coupon": ""
       },
       {
         "id": 3,
@@ -36,9 +36,9 @@
         "category": "HOTELRESORT",
         "lowestPrice": 95000,
         "discountPrice": 80000,
-        "imageUrl": "https://avatars.githubusercontent.com/u/81469686?v=4",
+        "imageUrl": "https://josunhotel.com/util/file/download.do?fileSn=1763080&sysCode=TWC",
         "soldOut": false,
-        "coupon": "10000원 할인"
+        "coupon": "10,000원 즉시 할인"
       },
       {
         "id": 4,
@@ -46,10 +46,10 @@
         "address": "서울특별시 중구 소공로 106",
         "category": "HOTELRESORT",
         "lowestPrice": 95000,
-        "discountPrice": 80000,
-        "imageUrl": "https://avatars.githubusercontent.com/u/81469686?v=4",
+        "discountPrice": 0,
+        "imageUrl": "https://josunhotel.com/util/file/download.do?fileSn=1763080&sysCode=TWC",
         "soldOut": false,
-        "coupon": "10000원 할인"
+        "coupon": ""
       },
       {
         "id": 5,
@@ -58,9 +58,9 @@
         "category": "HOTELRESORT",
         "lowestPrice": 95000,
         "discountPrice": 80000,
-        "imageUrl": "https://avatars.githubusercontent.com/u/81469686?v=4",
+        "imageUrl": "https://josunhotel.com/util/file/download.do?fileSn=1763080&sysCode=TWC",
         "soldOut": false,
-        "coupon": "10000원 할인"
+        "coupon": "10,000원 즉시 할인"
       },
       {
         "id": 6,
@@ -69,9 +69,9 @@
         "category": "HOTELRESORT",
         "lowestPrice": 95000,
         "discountPrice": 80000,
-        "imageUrl": "https://avatars.githubusercontent.com/u/81469686?v=4",
+        "imageUrl": "https://josunhotel.com/util/file/download.do?fileSn=1763080&sysCode=TWC",
         "soldOut": false,
-        "coupon": "10000원 할인"
+        "coupon": "10,000원 즉시 할인"
       },
       {
         "id": 7,
@@ -79,10 +79,10 @@
         "address": "서울특별시 중구 소공로 106",
         "category": "HOTELRESORT",
         "lowestPrice": 95000,
-        "discountPrice": 80000,
-        "imageUrl": "https://avatars.githubusercontent.com/u/81469686?v=4",
+        "discountPrice": 0,
+        "imageUrl": "https://josunhotel.com/util/file/download.do?fileSn=1763080&sysCode=TWC",
         "soldOut": false,
-        "coupon": "10000원 할인"
+        "coupon": ""
       },
       {
         "id": 8,
@@ -91,9 +91,9 @@
         "category": "HOTELRESORT",
         "lowestPrice": 95000,
         "discountPrice": 80000,
-        "imageUrl": "https://avatars.githubusercontent.com/u/81469686?v=4",
+        "imageUrl": "https://josunhotel.com/util/file/download.do?fileSn=1763080&sysCode=TWC",
         "soldOut": false,
-        "coupon": "10000원 할인"
+        "coupon": "10,000원 즉시 할인"
       },
       {
         "id": 9,
@@ -101,10 +101,10 @@
         "address": "서울특별시 중구 소공로 106",
         "category": "HOTELRESORT",
         "lowestPrice": 95000,
-        "discountPrice": 80000,
-        "imageUrl": "https://avatars.githubusercontent.com/u/81469686?v=4",
+        "discountPrice": 0,
+        "imageUrl": "https://josunhotel.com/util/file/download.do?fileSn=1763080&sysCode=TWC",
         "soldOut": false,
-        "coupon": "10000원 할인"
+        "coupon": ""
       },
       {
         "id": 10,
@@ -113,9 +113,9 @@
         "category": "HOTELRESORT",
         "lowestPrice": 95000,
         "discountPrice": 80000,
-        "imageUrl": "https://avatars.githubusercontent.com/u/81469686?v=4",
+        "imageUrl": "https://josunhotel.com/util/file/download.do?fileSn=1763080&sysCode=TWC",
         "soldOut": false,
-        "coupon": "10000원 할인"
+        "coupon": "10,000원 즉시 할인"
       },
       {
         "id": 11,
@@ -124,9 +124,9 @@
         "category": "HOTELRESORT",
         "lowestPrice": 95000,
         "discountPrice": 80000,
-        "imageUrl": "https://avatars.githubusercontent.com/u/81469686?v=4",
+        "imageUrl": "https://josunhotel.com/util/file/download.do?fileSn=1763080&sysCode=TWC",
         "soldOut": false,
-        "coupon": "10000원 할인"
+        "coupon": "10,000원 즉시 할인"
       },
       {
         "id": 12,
@@ -135,9 +135,9 @@
         "category": "HOTELRESORT",
         "lowestPrice": 95000,
         "discountPrice": 80000,
-        "imageUrl": "https://avatars.githubusercontent.com/u/81469686?v=4",
+        "imageUrl": "https://josunhotel.com/util/file/download.do?fileSn=1763080&sysCode=TWC",
         "soldOut": false,
-        "coupon": "10000원 할인"
+        "coupon": "10,000원 즉시 할인"
       }
     ]
   }

--- a/public/data/allAccommodations.json
+++ b/public/data/allAccommodations.json
@@ -1,93 +1,144 @@
 {
-  "status": "SUCCESS",
+  "message": "성공적으로 숙소 목록을 조회 했습니다.",
   "data": {
+    "pageNum": 1,
+    "pageSize": 12,
+    "totalPages": 8,
+    "totalElements": 96,
+    "isLast": false,
     "accommodations": [
       {
         "id": 1,
-        "name": "춘천세종호텔",
-        "region": "GANGWON",
+        "name": "웨스틴 조선 서울",
+        "address": "서울특별시 중구 소공로 106",
         "category": "HOTELRESORT",
-        "lowestPrice": 45000,
-        "image": "1.jpg",
-        "soldOut": true,
-        "accommodationOption": {
-          "hasSmokingRoom": true,
-          "hasPetRoom": false,
-          "hasParkingLot": true,
-          "hasWifi": true,
-          "hasSwimmingPool": false,
-          "hasGym": false,
-          "hasBreakfast": true,
-          "hasRestaurant": false,
-          "hasCookingRoom": false
-        }
+        "lowestPrice": 95000,
+        "discountPrice": 80000,
+        "imageUrl": "https://avatars.githubusercontent.com/u/81469686?v=4",
+        "soldOut": false,
+        "coupon": "10000원 할인"
       },
       {
         "id": 2,
-        "name": "파도소리펜션",
-        "region": "GYEONGSANG",
-        "category": "PENSION",
-        "lowestPrice": 100000,
-        "image": "2.jpg",
+        "name": "웨스틴 조선 서울",
+        "address": "서울특별시 중구 소공로 106",
+        "category": "HOTELRESORT",
+        "lowestPrice": 95000,
+        "discountPrice": 80000,
+        "imageUrl": "https://avatars.githubusercontent.com/u/81469686?v=4",
         "soldOut": false,
-        "accommodationOption": {
-          "hasSmokingRoom": true,
-          "hasPetRoom": true,
-          "hasParkingLot": true,
-          "hasWifi": true,
-          "hasSwimmingPool": false,
-          "hasGym": false,
-          "hasBreakfast": true,
-          "hasRestaurant": false,
-          "hasCookingRoom": true
-        }
+        "coupon": "10000원 할인"
       },
       {
         "id": 3,
-        "name": "럭셔리관광호텔(오산)",
-        "region": "GYEONGGI",
+        "name": "웨스틴 조선 서울",
+        "address": "서울특별시 중구 소공로 106",
         "category": "HOTELRESORT",
-        "lowestPrice": 65000,
-        "image": "3.jpg",
+        "lowestPrice": 95000,
+        "discountPrice": 80000,
+        "imageUrl": "https://avatars.githubusercontent.com/u/81469686?v=4",
         "soldOut": false,
-        "accommodationOption": {
-          "hasSmokingRoom": true,
-          "hasPetRoom": true,
-          "hasParkingLot": true,
-          "hasWifi": true,
-          "hasSwimmingPool": true,
-          "hasGym": true,
-          "hasBreakfast": true,
-          "hasRestaurant": true,
-          "hasCookingRoom": true
-        }
+        "coupon": "10000원 할인"
       },
       {
         "id": 4,
-        "name": "포포인츠 바이 쉐라톤 서울 구로",
-        "region": "SEOUL",
-        "category": "MOTEL",
-        "lowestPrice": 40000,
-        "image": "4.jpg",
+        "name": "웨스틴 조선 서울",
+        "address": "서울특별시 중구 소공로 106",
+        "category": "HOTELRESORT",
+        "lowestPrice": 95000,
+        "discountPrice": 80000,
+        "imageUrl": "https://avatars.githubusercontent.com/u/81469686?v=4",
         "soldOut": false,
-        "accommodationOption": {
-          "hasSmokingRoom": true,
-          "hasPetRoom": false,
-          "hasParkingLot": true,
-          "hasWifi": true,
-          "hasSwimmingPool": false,
-          "hasGym": false,
-          "hasBreakfast": false,
-          "hasRestaurant": false,
-          "hasCookingRoom": false
-        }
+        "coupon": "10000원 할인"
+      },
+      {
+        "id": 5,
+        "name": "웨스틴 조선 서울",
+        "address": "서울특별시 중구 소공로 106",
+        "category": "HOTELRESORT",
+        "lowestPrice": 95000,
+        "discountPrice": 80000,
+        "imageUrl": "https://avatars.githubusercontent.com/u/81469686?v=4",
+        "soldOut": false,
+        "coupon": "10000원 할인"
+      },
+      {
+        "id": 6,
+        "name": "웨스틴 조선 서울",
+        "address": "서울특별시 중구 소공로 106",
+        "category": "HOTELRESORT",
+        "lowestPrice": 95000,
+        "discountPrice": 80000,
+        "imageUrl": "https://avatars.githubusercontent.com/u/81469686?v=4",
+        "soldOut": false,
+        "coupon": "10000원 할인"
+      },
+      {
+        "id": 7,
+        "name": "웨스틴 조선 서울",
+        "address": "서울특별시 중구 소공로 106",
+        "category": "HOTELRESORT",
+        "lowestPrice": 95000,
+        "discountPrice": 80000,
+        "imageUrl": "https://avatars.githubusercontent.com/u/81469686?v=4",
+        "soldOut": false,
+        "coupon": "10000원 할인"
+      },
+      {
+        "id": 8,
+        "name": "웨스틴 조선 서울",
+        "address": "서울특별시 중구 소공로 106",
+        "category": "HOTELRESORT",
+        "lowestPrice": 95000,
+        "discountPrice": 80000,
+        "imageUrl": "https://avatars.githubusercontent.com/u/81469686?v=4",
+        "soldOut": false,
+        "coupon": "10000원 할인"
+      },
+      {
+        "id": 9,
+        "name": "웨스틴 조선 서울",
+        "address": "서울특별시 중구 소공로 106",
+        "category": "HOTELRESORT",
+        "lowestPrice": 95000,
+        "discountPrice": 80000,
+        "imageUrl": "https://avatars.githubusercontent.com/u/81469686?v=4",
+        "soldOut": false,
+        "coupon": "10000원 할인"
+      },
+      {
+        "id": 10,
+        "name": "웨스틴 조선 서울",
+        "address": "서울특별시 중구 소공로 106",
+        "category": "HOTELRESORT",
+        "lowestPrice": 95000,
+        "discountPrice": 80000,
+        "imageUrl": "https://avatars.githubusercontent.com/u/81469686?v=4",
+        "soldOut": false,
+        "coupon": "10000원 할인"
+      },
+      {
+        "id": 11,
+        "name": "웨스틴 조선 서울",
+        "address": "서울특별시 중구 소공로 106",
+        "category": "HOTELRESORT",
+        "lowestPrice": 95000,
+        "discountPrice": 80000,
+        "imageUrl": "https://avatars.githubusercontent.com/u/81469686?v=4",
+        "soldOut": false,
+        "coupon": "10000원 할인"
+      },
+      {
+        "id": 12,
+        "name": "웨스틴 조선 서울",
+        "address": "서울특별시 중구 소공로 106",
+        "category": "HOTELRESORT",
+        "lowestPrice": 95000,
+        "discountPrice": 80000,
+        "imageUrl": "https://avatars.githubusercontent.com/u/81469686?v=4",
+        "soldOut": false,
+        "coupon": "10000원 할인"
       }
-    ],
-    "pageNum": 1,
-    "pageSize": 12,
-    "totalPages": 0,
-    "totalElements": 4,
-    "isFirst": true,
-    "isLast": true
+    ]
   }
 }

--- a/public/data/allAccommodations.json
+++ b/public/data/allAccommodations.json
@@ -24,7 +24,7 @@
         "address": "서울특별시 중구 소공로 106",
         "category": "HOTELRESORT",
         "lowestPrice": 95000,
-        "discountPrice": 0,
+        "discountPrice": 95000,
         "imageUrl": "https://josunhotel.com/util/file/download.do?fileSn=1763080&sysCode=TWC",
         "soldOut": false,
         "coupon": ""
@@ -46,7 +46,7 @@
         "address": "서울특별시 중구 소공로 106",
         "category": "HOTELRESORT",
         "lowestPrice": 95000,
-        "discountPrice": 0,
+        "discountPrice": 95000,
         "imageUrl": "https://josunhotel.com/util/file/download.do?fileSn=1763080&sysCode=TWC",
         "soldOut": false,
         "coupon": ""
@@ -79,7 +79,7 @@
         "address": "서울특별시 중구 소공로 106",
         "category": "HOTELRESORT",
         "lowestPrice": 95000,
-        "discountPrice": 0,
+        "discountPrice": 95000,
         "imageUrl": "https://josunhotel.com/util/file/download.do?fileSn=1763080&sysCode=TWC",
         "soldOut": false,
         "coupon": ""
@@ -101,7 +101,7 @@
         "address": "서울특별시 중구 소공로 106",
         "category": "HOTELRESORT",
         "lowestPrice": 95000,
-        "discountPrice": 0,
+        "discountPrice": 95000,
         "imageUrl": "https://josunhotel.com/util/file/download.do?fileSn=1763080&sysCode=TWC",
         "soldOut": false,
         "coupon": ""

--- a/src/api/getAllAccommodationsApi.ts
+++ b/src/api/getAllAccommodationsApi.ts
@@ -1,0 +1,44 @@
+import instance from "./instanceApi";
+
+export type AccommodationParams = {
+  category: string;
+  page: number;
+  hasCoupon: boolean;
+};
+export type Accommodation = {
+  id: number;
+  name: string;
+  address: string;
+  category: string;
+  lowestPrice: number;
+  discountPrice: number;
+  imageUrl: string;
+  soldOut: boolean;
+  coupon: string;
+};
+export type Accommodations = {
+  pageNum: number;
+  pageSize: number;
+  totalPages: number;
+  totalElements: number;
+  isLast: boolean;
+  accommodations: Accommodation[];
+};
+export type ResponseAccommodation = {
+  message: string;
+  data: Accommodations;
+};
+
+export const getAllAccommodations = ({
+  category = "string",
+  hasCoupon = false,
+  page = 1,
+}: AccommodationParams) => {
+  return instance.get<ResponseAccommodation>("/api/accommodations", {
+    params: {
+      category,
+      hasCoupon,
+      page,
+    },
+  });
+};

--- a/src/api/getAllAccommodationsApi.ts
+++ b/src/api/getAllAccommodationsApi.ts
@@ -4,6 +4,7 @@ export type AccommodationParams = {
   category: string;
   page: number;
   hasCoupon: boolean;
+  keyword: string;
 };
 export type Accommodation = {
   id: number;
@@ -32,6 +33,7 @@ export type ResponseAccommodation = {
 export const getAllAccommodations = ({
   category = "string",
   hasCoupon = false,
+  keyword = "",
   page = 1,
 }: AccommodationParams) => {
   return instance.get<ResponseAccommodation>("/api/accommodations", {
@@ -39,6 +41,7 @@ export const getAllAccommodations = ({
       category,
       hasCoupon,
       page,
+      keyword,
     },
   });
 };

--- a/src/components/common/header/categoryFilter/CategoryFilter.tsx
+++ b/src/components/common/header/categoryFilter/CategoryFilter.tsx
@@ -9,7 +9,7 @@ import GUESTHOUSE from "../../../../assets/categoryIcons/guest-house.jpg";
 import HOTELRESORT from "../../../../assets/categoryIcons/hotel.jpg";
 import MOTEL from "../../../../assets/categoryIcons/motel.jpg";
 
-import { useSetRecoilState } from "recoil";
+import { useRecoilState, useSetRecoilState } from "recoil";
 
 // 다른 컴포넌트
 import { filterState, filterStateTypes } from "@/states/filterState";
@@ -17,6 +17,7 @@ import { AccommodationType } from "@/types/accommodations";
 import { responseState } from "@/states/responseState";
 import { detailState } from "@/states/detailState";
 import { categoryState, hasCouponState } from "@/states/categoryState";
+import { searchState } from "@/states/searchState";
 
 interface categoryTypes {
   name: string;
@@ -29,9 +30,9 @@ const CategoryFilter = () => {
   const setFilterStates = useSetRecoilState(filterState);
   const setResponseStates = useSetRecoilState(responseState);
   const setDetailStates = useSetRecoilState(detailState);
-  const [isDiscounting, setIsDiscounting] = useState(false);
-  const setCategory = useSetRecoilState(categoryState);
-  const setHasCoupon = useSetRecoilState(hasCouponState);
+  const [category, setCategory] = useRecoilState(categoryState);
+  const [hasCoupon, setHasCoupon] = useRecoilState(hasCouponState);
+  const [keyword, setKeyword] = useRecoilState(searchState);
 
   const categoriesData: //
   categoryTypes[] = [
@@ -61,6 +62,7 @@ const CategoryFilter = () => {
       if (arg.name === categoryName) {
         engName = arg.engName;
         setCategory(arg.engName);
+        if (keyword !== "") setKeyword("");
         return { ...arg, select: true };
       }
       return { ...arg, select: false };
@@ -81,26 +83,26 @@ const CategoryFilter = () => {
     }));
   };
 
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setIsDiscounting(event?.currentTarget.checked);
+  const handleChange = () => {
     setHasCoupon(prev => !prev);
+    if (keyword !== "") setKeyword("");
   };
 
   return (
     <div className="category-filter__container">
       <div className="category-filter__inner">
-        {categories.map((category, idx) =>
-          category.select === true ? ( //
+        {categoriesData.map((item, idx) =>
+          item.engName === category ? ( //
             <button //
               key={`category-filter-${idx}`}
               className="filter__button categorySelect"
               onClick={_debounce(() => {
                 setDetailStates([]);
-                changeCategoryHandler(category.name);
+                changeCategoryHandler(item.name);
               }, 100)}
             >
-              <img src={category.img}></img>
-              <span>{category.name}</span>
+              <img src={item.img}></img>
+              <span>{item.name}</span>
             </button>
           ) : (
             <button //
@@ -108,24 +110,27 @@ const CategoryFilter = () => {
               className="filter__button"
               onClick={_debounce(() => {
                 setDetailStates([]);
-                changeCategoryHandler(category.name);
+                changeCategoryHandler(item.name);
               }, 100)}
             >
-              <img src={category.img}></img>
-              <span>{category.name}</span>
+              <img src={item.img}></img>
+              <span>{item.name}</span>
             </button>
           )
         )}
         <div className="filter__adjust-height">
-          <div
-            className={`filter__button-detail ${isDiscounting && "discount"}`}
-          >
+          <div className={`filter__button-detail ${hasCoupon && "discount"}`}>
             <input
               type="checkbox"
               className="discount-filter"
               onChange={handleChange}
+              checked={hasCoupon}
             />
-            <label className="discount-filter-text">할인숙소</label>
+            <label
+              className={`discount-filter-text ${hasCoupon && "discount"}`}
+            >
+              할인숙소
+            </label>
           </div>
         </div>
       </div>

--- a/src/components/common/header/categoryFilter/CategoryFilter.tsx
+++ b/src/components/common/header/categoryFilter/CategoryFilter.tsx
@@ -16,6 +16,7 @@ import { filterState, filterStateTypes } from "@/states/filterState";
 import { AccommodationType } from "@/types/accommodations";
 import { responseState } from "@/states/responseState";
 import { detailState } from "@/states/detailState";
+import { categoryState, hasCouponState } from "@/states/categoryState";
 
 interface categoryTypes {
   name: string;
@@ -29,6 +30,8 @@ const CategoryFilter = () => {
   const setResponseStates = useSetRecoilState(responseState);
   const setDetailStates = useSetRecoilState(detailState);
   const [isDiscounting, setIsDiscounting] = useState(false);
+  const setCategory = useSetRecoilState(categoryState);
+  const setHasCoupon = useSetRecoilState(hasCouponState);
 
   const categoriesData: //
   categoryTypes[] = [
@@ -57,6 +60,7 @@ const CategoryFilter = () => {
     const copy: categoryTypes[] = categories.slice().map(arg => {
       if (arg.name === categoryName) {
         engName = arg.engName;
+        setCategory(arg.engName);
         return { ...arg, select: true };
       }
       return { ...arg, select: false };
@@ -79,6 +83,7 @@ const CategoryFilter = () => {
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setIsDiscounting(event?.currentTarget.checked);
+    setHasCoupon(prev => !prev);
   };
 
   return (

--- a/src/components/common/header/categoryFilter/categoryFilter.scss
+++ b/src/components/common/header/categoryFilter/categoryFilter.scss
@@ -60,14 +60,13 @@
   accent-color: coral(500);
 }
 
-.discount-filter:checked + .discount-filter-text {
-  color: coral(500);
-}
-
 .discount-filter-text {
   font-size: rem(14);
   font-weight: 400;
   color: #000;
+  &.discount {
+    color: coral(500);
+  }
 }
 
 .categorySelect {

--- a/src/components/common/header/searchFilter/SearchFilter.tsx
+++ b/src/components/common/header/searchFilter/SearchFilter.tsx
@@ -1,42 +1,38 @@
 import { useEffect, useRef } from "react";
 import { IoIosSearch } from "react-icons/io";
 import "./searchFilter.scss";
-import { searchAccommodationByName } from "@/hooks/fetchAccommodations";
-import { useRecoilState } from "recoil";
-import { detailState } from "@/states/detailState";
-import { Accommodation } from "@/states/detailState";
+
 import { useNavigate } from "react-router-dom";
+import { useRecoilState, useSetRecoilState } from "recoil";
+import { searchState } from "@/states/searchState";
+import { categoryState, hasCouponState } from "@/states/categoryState";
 
 const SearchFilter = () => {
   const navigate = useNavigate();
-  const [detailStates, setDetailStates] = useRecoilState(detailState);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const [keyword, setKeyword] = useRecoilState(searchState);
+  const setCategory = useSetRecoilState(categoryState);
+  const setHasCoupon = useSetRecoilState(hasCouponState);
 
-  useEffect(() => {
-    if (detailStates.length === 0) {
-      if (inputRef.current) inputRef.current.value = "";
-    }
-  }, [detailStates]);
   const searchSubmitHandler: React.FormEventHandler<HTMLFormElement> = e => {
     e.preventDefault();
     const name = inputRef.current?.value;
-    if (name?.trim().length === 0) {
+    if (name?.trim().length === 0 || !name) {
       window.alert("검색어를 입력해주세요.");
       return;
     }
 
     navigate("/");
-    searchAccommodationByName(name!)
-      .then(res => {
-        if (res.accommodations.length) {
-          return res.accommodations;
-        } else {
-          alert("해당하는 조건의 숙소가 없습니다.");
-          throw new Error("해당하는 조건의 숙소가 없습니다.");
-        }
-      })
-      .then((res: Accommodation[]) => setDetailStates(res));
+    setKeyword(name);
+    setCategory("ALL");
+    setHasCoupon(false);
   };
+
+  useEffect(() => {
+    if (keyword === "" && inputRef.current) {
+      inputRef.current.value = "";
+    }
+  }, [keyword]);
 
   return (
     <form onSubmit={searchSubmitHandler} style={{ position: "relative" }}>

--- a/src/hooks/quries/useMain.ts
+++ b/src/hooks/quries/useMain.ts
@@ -1,0 +1,31 @@
+import {
+  ResponseAccommodation,
+  getAllAccommodations,
+} from "@/api/getAllAccommodationsApi";
+import { AxiosError, AxiosResponse } from "axios";
+import { useInfiniteQuery } from "react-query";
+
+export const useGetAllAccommodations = (
+  category: string,
+  hasCoupon: boolean
+) => {
+  return useInfiniteQuery<
+    AxiosResponse<ResponseAccommodation>,
+    AxiosError,
+    AxiosResponse<ResponseAccommodation>
+  >(
+    ["accommodations-list"],
+    ({ pageParam = 1 }) =>
+      getAllAccommodations({ page: pageParam, category, hasCoupon }),
+    {
+      getNextPageParam: ({
+        data: {
+          data: { pageNum, totalPages },
+        },
+      }) => {
+        const nextPage = pageNum + 1;
+        return totalPages > pageNum ? nextPage : undefined;
+      },
+    }
+  );
+};

--- a/src/hooks/quries/useMain.ts
+++ b/src/hooks/quries/useMain.ts
@@ -7,7 +7,8 @@ import { useInfiniteQuery } from "react-query";
 
 export const useGetAllAccommodations = (
   category: string,
-  hasCoupon: boolean
+  hasCoupon: boolean,
+  keyword: string
 ) => {
   return useInfiniteQuery<
     AxiosResponse<ResponseAccommodation>,
@@ -16,7 +17,7 @@ export const useGetAllAccommodations = (
   >(
     ["accommodations-list"],
     ({ pageParam = 1 }) =>
-      getAllAccommodations({ page: pageParam, category, hasCoupon }),
+      getAllAccommodations({ page: pageParam, category, hasCoupon, keyword }),
     {
       getNextPageParam: ({
         data: {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,14 +4,15 @@ import { RouterProvider } from "react-router-dom";
 import router from "./routes/router.tsx";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { RecoilRoot } from "recoil";
-
+import { worker } from "../src/mocks/browsers.ts";
+worker.start();
 const queryClient = new QueryClient();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <RecoilRoot>
       <QueryClientProvider client={queryClient}>
-          <RouterProvider router={router} />
+        <RouterProvider router={router} />
       </QueryClientProvider>
     </RecoilRoot>
   </React.StrictMode>

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,24 +1,13 @@
 import { http, HttpResponse } from "msw";
-import accommodationDetail from "../../public/data/accommodationDetail.json";
 import allAccommodations from "../../public/data/allAccommodations.json";
-
-const getHotelResolver = () => {
-  return HttpResponse.json(accommodationDetail);
-};
-const postHotelResolver = async ({ request }: any) => {
-  const newPost = await request.json();
-  console.log("newPost", newPost);
-
-  return HttpResponse.json(newPost, { status: 201 });
-};
 
 const getAccommodationResolver = () => {
   return HttpResponse.json(allAccommodations);
 };
 
 export const handlers = [
-  //
-  http.get("/accommodation", getHotelResolver),
-  http.post("/accommodation", postHotelResolver),
-  http.get("/accomodations", getAccommodationResolver),
+  http.get(
+    `${import.meta.env.VITE_API_BASE_URL}/api/accommodations`,
+    getAccommodationResolver
+  ),
 ];

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,31 +1,30 @@
-import { useQuery } from "react-query";
 import AccomodationItem from "./accomodationItem/AccomodationItem";
 import LoadingAnimation from "@/components/loadingAnimation/LoadingAnimation";
 import "./home.scss";
 
-import { useRecoilState, useRecoilValue } from "recoil";
-import { filterState } from "@/states/filterState";
-import { format } from "date-fns";
-import { fetchAccommodationsData } from "@/hooks/fetchAccommodations";
-import { Accommodation } from "../../types/accommodations";
-import { responseState } from "@/states/responseState";
-import { useEffect, useRef } from "react";
-import { detailState } from "@/states/detailState";
+import { useEffect, useMemo, useRef } from "react";
 import ErrorAnimation from "@/components/errorAnimation/ErrorAnimation";
+import { useGetAllAccommodations } from "@/hooks/quries/useMain";
 
 const Home = () => {
-  const detailFiltered = useRecoilValue(detailState);
-  const [filterStates] = useRecoilState(filterState);
-  const [responseStates, setResponseStates] = useRecoilState(responseState);
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isError,
+    isLoading,
+    refetch,
+    remove,
+  } = useGetAllAccommodations("ALL", false);
 
   const scrollRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
     // Intersection Observer 생성
     const observer = new IntersectionObserver(entries => {
       entries.forEach(entry => {
-        if (entry.isIntersecting) {
+        if (entry.isIntersecting && hasNextPage) {
           // 타겟 요소가 화면에 나타남
-          setTimeout(() => refetch(), 500);
+          setTimeout(() => fetchNextPage(), 500);
         }
       });
     });
@@ -36,35 +35,13 @@ const Home = () => {
       observer.observe(targetElements!);
     }
     return () => observer.disconnect();
-  }, [filterStates, scrollRef.current]);
+  }, [scrollRef.current]);
 
-  // 시작일 종료일 만들기
-  const startDate = format(filterStates.startDate, "yyyy-MM-dd");
-  const endDate = filterStates.endDate
-    ? format(filterStates.endDate, "yyyy-MM-dd")
-    : startDate;
-
-  // 리액트 쿼리
-  const { refetch, isLoading, isError } = useQuery({
-    queryKey: ["accommodations", filterStates.current],
-    queryFn: () =>
-      fetchAccommodationsData(
-        filterStates.current.locale,
-        startDate,
-        endDate,
-        filterStates.current.category,
-        filterStates.current.amount,
-        responseStates.pageIndex
-      ),
-    staleTime: 500000,
-    onSuccess: data => {
-      setResponseStates(prev => ({
-        pageIndex: prev.pageIndex + 1,
-        responseArray: [...prev.responseArray, ...data.accommodations],
-      }));
-    },
-  });
-
+  const accommodationsItems = useMemo(
+    () => data?.pages.flatMap(page => page.data.data.accommodations),
+    [data]
+  );
+  console.log(accommodationsItems);
   if (isLoading) {
     return (
       <div className="home__animation-container">
@@ -80,17 +57,10 @@ const Home = () => {
       </div>
     );
   }
-
   return (
     <div className="home-wrapper">
       <div className="home-inner">
-        {detailFiltered.length === 0
-          ? responseStates.responseArray.map((acc: Accommodation) => (
-              <AccomodationItem key={acc.id} data={acc} />
-            ))
-          : detailFiltered.map(acc => (
-              <AccomodationItem key={acc.id} data={acc} />
-            ))}
+        {accommodationsItems?.map(item => <AccomodationItem data={item} />)}
         <div className="target-div" ref={scrollRef}>
           @2023 빨리 잡아
         </div>

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -5,8 +5,12 @@ import "./home.scss";
 import { useEffect, useMemo, useRef } from "react";
 import ErrorAnimation from "@/components/errorAnimation/ErrorAnimation";
 import { useGetAllAccommodations } from "@/hooks/quries/useMain";
+import { useRecoilValue } from "recoil";
+import { categoryState, hasCouponState } from "@/states/categoryState";
 
 const Home = () => {
+  const category = useRecoilValue(categoryState);
+  const hasCoupon = useRecoilValue(hasCouponState);
   const {
     data,
     fetchNextPage,
@@ -15,7 +19,14 @@ const Home = () => {
     isLoading,
     refetch,
     remove,
-  } = useGetAllAccommodations("ALL", false);
+  } = useGetAllAccommodations(category, hasCoupon);
+
+  useEffect(() => {
+    refetch();
+    return () => {
+      remove();
+    };
+  }, [hasCoupon, category]);
 
   const scrollRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
@@ -41,7 +52,6 @@ const Home = () => {
     () => data?.pages.flatMap(page => page.data.data.accommodations),
     [data]
   );
-  console.log(accommodationsItems);
   if (isLoading) {
     return (
       <div className="home__animation-container">

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -7,10 +7,12 @@ import ErrorAnimation from "@/components/errorAnimation/ErrorAnimation";
 import { useGetAllAccommodations } from "@/hooks/quries/useMain";
 import { useRecoilValue } from "recoil";
 import { categoryState, hasCouponState } from "@/states/categoryState";
+import { searchState } from "@/states/searchState";
 
 const Home = () => {
   const category = useRecoilValue(categoryState);
   const hasCoupon = useRecoilValue(hasCouponState);
+  const keyword = useRecoilValue(searchState);
   const {
     data,
     fetchNextPage,
@@ -19,14 +21,14 @@ const Home = () => {
     isLoading,
     refetch,
     remove,
-  } = useGetAllAccommodations(category, hasCoupon);
+  } = useGetAllAccommodations(category, hasCoupon, keyword);
 
   useEffect(() => {
     refetch();
     return () => {
       remove();
     };
-  }, [hasCoupon, category]);
+  }, [hasCoupon, category, keyword]);
 
   const scrollRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {

--- a/src/pages/home/accomodationItem/AccomodationItem.tsx
+++ b/src/pages/home/accomodationItem/AccomodationItem.tsx
@@ -1,12 +1,9 @@
 import "./accomodationItem.scss";
 import { useNavigate } from "react-router-dom";
 import { accommodationCategoryData } from "@/constant/categories";
-import { Accommodation } from "../../../types/accommodations";
-interface accommodationProps {
-  data: Accommodation;
-}
+import { Accommodation } from "@/api/getAllAccommodationsApi";
 
-const AccommodationItem = ({ data }: accommodationProps) => {
+const AccommodationItem = ({ data }: { data: Accommodation }) => {
   const navigate = useNavigate();
 
   const navigateHandler = () => {
@@ -18,12 +15,14 @@ const AccommodationItem = ({ data }: accommodationProps) => {
       <div
         className="accomdationItem-container__image-box"
         style={{
-          backgroundImage: `url(https://fastcatch-image.s3.ap-northeast-2.amazonaws.com/${data.image})`,
+          backgroundImage: `url(${data.imageUrl})`,
         }}
       >
-        <div className="accomdationItem-container__coupon-box">
-          10,000원 즉시할인
-        </div>
+        {data.coupon && (
+          <div className="accomdationItem-container__coupon-box">
+            {data.coupon}
+          </div>
+        )}
       </div>
       <div className="accomdationItem-container__desc-box">
         <div className="item-info">
@@ -35,10 +34,18 @@ const AccommodationItem = ({ data }: accommodationProps) => {
           </div>
         </div>
         <div className="item-price">
-          {/* <span className="text-body1">최저가</span> */}
-          <div className="coupon-box">쿠폰가</div>
+          {data.coupon === "" ? (
+            <span className="price-info">최저가</span>
+          ) : (
+            <div className="coupon-box">쿠폰가</div>
+          )}
+
           <div className="price-container">
-            <div className="price"> {data.lowestPrice.toLocaleString()}원</div>
+            {data.discountPrice !== 0 && (
+              <div className="price">
+                {data.discountPrice.toLocaleString()}원
+              </div>
+            )}
             <div className="lowest-price">
               {data.lowestPrice.toLocaleString()}원
             </div>

--- a/src/pages/home/accomodationItem/AccomodationItem.tsx
+++ b/src/pages/home/accomodationItem/AccomodationItem.tsx
@@ -41,7 +41,7 @@ const AccommodationItem = ({ data }: { data: Accommodation }) => {
           )}
 
           <div className="price-container">
-            {data.discountPrice !== 0 && (
+            {data.discountPrice !== data.lowestPrice && (
               <div className="price">
                 {data.discountPrice.toLocaleString()}원
               </div>

--- a/src/pages/home/accomodationItem/accomodationItem.scss
+++ b/src/pages/home/accomodationItem/accomodationItem.scss
@@ -36,7 +36,9 @@
 
   &__desc-box {
     display: flex;
+    height: rem(100);
     flex-direction: column;
+    justify-content: space-between;
 
     .item-info {
       display: flex;
@@ -104,4 +106,9 @@
   &:hover {
     transform: translateY(rem(-4));
   }
+}
+.price-info {
+  color: gray(700);
+  font-size: rem(18);
+  font-weight: 400;
 }

--- a/src/states/categoryState.ts
+++ b/src/states/categoryState.ts
@@ -1,0 +1,11 @@
+import { atom } from "recoil";
+
+export const categoryState = atom<string>({
+  key: "categoryState",
+  default: "ALL",
+});
+
+export const hasCouponState = atom<boolean>({
+  key: "hasCouponState",
+  default: false,
+});

--- a/src/states/searchState.ts
+++ b/src/states/searchState.ts
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const searchState = atom<string>({
+  key: "searchState",
+  default: "LL",
+});


### PR DESCRIPTION
### ⛳️ Task
close #5 
close #8  
close #26 
- [X] Main page 검색 기능 구현
- [X] msw 구축 및 메인 페이지 더미 데이터 생성
- [X] Main page api 수정
- [X] Main page 필터 재구현

### ✍️ Note

**일단 메인 페이지 전체 기능은 완료했습니다 !**

저희 API 는 검색 키워드, 할인 필터 클릭 여부, 카테고리 를 쿼리 스트링으로 한 번에 받기에
아래와 같은 이슈가 있었습니다

게스트 하우스 필터 클릭 후 , 할인 숙소를 클릭하면 게스트 하우스 카테고리 중 할인 쿠폰이 있는 숙소들만 응답
이때 웨스틴 이라는 검색을 한다면 게스트 하우스 중 할인 쿠폰이 있는 웨스틴 숙소만 보여주게 되는데 
이렇게 플로우로 가면 검색 했을 때 제공되는 숙소가 거의 없을 뿐더러, **검색 기능의 목적**이 카테고리 필터에 할인 필터에 또 다른 필터를 거치는 게 아닌 **전체 검색** 이라고 판단을 하여
사용자가 검색을 했을 시 설정한 필터를 기본 값으로 돌려놓았습니다 ( 기본 값으로 필터를 설정하면 DB에 있는 전체 숙소 중 검색을 하게 됩니다)

사실 이 부분은 기획단에서 고려할 부분이긴 하지만 미니 프로젝트인 점을 감안해서 저희 팀에서 이 부분까지 꼼꼼히 체크할 필요는 없다고 생각해서 가장 일반적인 방식을 채택했습니다.


현재 msw 로 main page api는 통신 중이며 더미 데이터 인 점을 감안해주세요 ( 더미 데이터랑 통신하다 보니 좀 끊길 때가 많은 것 같은데 새로고침 해주시면 돼요! )

### ⚡️ Test

### 📸 Screenshot

<img width="990" alt="image" src="https://github.com/Upjuyanolja/FastCatch-FrontEnd/assets/81469686/0c3adeb0-c978-4159-af32-be2becea537b">


### 📎 Reference
