### PR TITLE
Style: 할인 쿠폰 선택 시 할인 가격 badge 추가

### DIFF
--- a/src/pages/order/discountBadge/DiscountBadge.tsx
+++ b/src/pages/order/discountBadge/DiscountBadge.tsx
@@ -1,0 +1,15 @@
+import "./discountBadge.scss";
+
+const DiscountBadge = () => {
+  return (
+    <>
+      <div className="discount-badge-container">
+        <div className="discount-badge">
+          <p>총 20,000원 할인 받았어요!</p>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default DiscountBadge;

--- a/src/pages/order/discountBadge/discountBadge.scss
+++ b/src/pages/order/discountBadge/discountBadge.scss
@@ -1,0 +1,27 @@
+@import "../../../styles/common.scss";
+.discount-badge-container {
+  display: flex;
+  justify-content: center;
+  margin-bottom: rem(8);
+  .discount-badge {
+    display: inline-block;
+    font-size: rem(16);
+    font-weight: bold;
+    border: 2px solid transparent;
+    background-image: linear-gradient($white, $white),
+      linear-gradient(to right, rgba(254, 57, 91, 1), rgba(255, 236, 232, 1));
+    background-origin: border-box;
+    background-clip: content-box, border-box;
+    border-radius: rem(100);
+    box-shadow: 0px 4px 4px 0px #0000001a;
+    overflow: hidden;
+    p {
+      background: linear-gradient(
+        to right,
+        rgba(255, 236, 232, 0),
+        rgba(255, 236, 232, 1)
+      );
+      padding: rem(12) rem(35);
+    }
+  }
+}

--- a/src/pages/order/discountBadge/discountBadge.scss
+++ b/src/pages/order/discountBadge/discountBadge.scss
@@ -9,7 +9,7 @@
     font-weight: bold;
     border: 2px solid transparent;
     background-image: linear-gradient($white, $white),
-      linear-gradient(to right, rgba(254, 57, 91, 1), rgba(255, 236, 232, 1));
+      linear-gradient(to right, rgba(255, 236, 232, 1), rgba(254, 57, 91, 1));
     background-origin: border-box;
     background-clip: content-box, border-box;
     border-radius: rem(100);


### PR DESCRIPTION
### ⛳️ Task

- [x] Style: 할인 쿠폰 선택 시 할인 가격 badge 추가

### ✍️ Note

Style: 할인 쿠폰 선택 시 할인 가격 badge 추가

수정 전
오른쪽 border 그라디언트 칼라와 아이템 내부 background 그라디언트 칼라가 마지막엔 같은 값으로 되어 오른쪽이 합쳐지는 듯이 보이는 현상이 있었습니다. 그래서 해당 사항을 UXUI 윤솔님께 문의해본 결과 디자인 의도를 가지고 만드신건 아니고 좌우 변경을 해주면 좋겠다는 답변을 받아서 수정하였습니다

### ⚡️ Test

### 📸 Screenshot
수정 전
<img width="266" alt="스크린샷 2023-12-28 오후 7 27 00" src="https://github.com/Upjuyanolja/FastCatch-FrontEnd/assets/98436988/3bd937c0-6bb8-4540-81be-0b1c29bbb2da">

수정 후
<img width="266" alt="스크린샷 2023-12-29 오전 10 48 24" src="https://github.com/Upjuyanolja/FastCatch-FrontEnd/assets/98436988/90bd593c-df6f-4e0c-80e9-ed02f2debe5e">


### 📎 Reference
